### PR TITLE
 Add podIP and ingameTime to crd

### DIFF
--- a/src/main/resources/kubernetes/strela.dev_minecraftservers.yaml
+++ b/src/main/resources/kubernetes/strela.dev_minecraftservers.yaml
@@ -49,6 +49,8 @@ spec:
                 type: string
               maxPlayers:
                 type: integer
+              serverType:
+                type: string
               template:
                 description: PodTemplateSpec describes the data a pod should have
                   when created from a template
@@ -7548,6 +7550,9 @@ spec:
                 type: string
               ready:
                 type: boolean
+              readyTime:
+                format: date-time
+                type: string
             type: object
         type: object
     served: true

--- a/src/main/resources/kubernetes/strela.dev_minecraftservers.yaml
+++ b/src/main/resources/kubernetes/strela.dev_minecraftservers.yaml
@@ -7539,8 +7539,13 @@ spec:
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
                   Important: Run "make" to regenerate code after modifying this file
                 type: boolean
+              ingameTime:
+                format: date-time
+                type: string
               playerCount:
                 type: integer
+              podIP:
+                type: string
               ready:
                 type: boolean
             type: object


### PR DESCRIPTION
The podIP and ingameTime is missing from the CRD, which causes the SDK to no longer work on the newest Strela dev version. This PR fixes that
